### PR TITLE
skip soft-deleted rows in methods with ByPk postfix #5

### DIFF
--- a/src/BaseManager.php
+++ b/src/BaseManager.php
@@ -257,17 +257,18 @@ abstract class BaseManager
     }
 
     /**
-     * @param $pk
+     * @param mixed $pk
+     * @param bool $withDeleted
      *
      * @return array
      */
-    public function findOneByPk($pk): ?array
+    public function findOneByPk($pk, bool $withDeleted = false): ?array
     {
         $query = $this->connection->createQueryBuilder();
         $query->select('*');
         $query->from($this->getEntity()->getTableName());
 
-        $this->applyPkFilterToQuery($query, $pk);
+        $this->applyPkFilterToQuery($query, $pk, $withDeleted);
 
         $result = $query->execute()->fetch();
         if ($result === null || $result === false) {
@@ -279,9 +280,10 @@ abstract class BaseManager
 
     /**
      * @param QueryBuilder $query
-     * @param $pk
+     * @param mixed $pk
+     * @param bool $withDeleted
      */
-    protected function applyPkFilterToQuery(QueryBuilder $query, $pk): void
+    protected function applyPkFilterToQuery(QueryBuilder $query, $pk, bool $withDeleted = false): void
     {
         if ($this->getEntity()->getPrimaryKey() === []) {
             throw EntityDefinitionException::withNoPrimaryKeyDefined();
@@ -299,6 +301,10 @@ abstract class BaseManager
                 }
                 $query->andWhere($pkColumn . ' = ' . $query->createNamedParameter($pk[$pkColumn]));
             }
+        }
+
+        if (false === $withDeleted && $this->getEntity()->isSoftDeletable()) {
+            $query->andWhere($this->getEntity()->getDeletedAtField() . ' IS NULL');
         }
     }
 

--- a/tests/BaseManagerTest.php
+++ b/tests/BaseManagerTest.php
@@ -1046,6 +1046,31 @@ SQL
         self::assertNull($data);
     }
 
+    public function testSuccessFindOneByPkWithDeletedFalse(): void
+    {
+        // arrange
+        $targetUser = self::USER_3;
+
+        // action
+        $resultUser = $this->manager->findOneByPk($targetUser['id']);
+
+        // assert
+        self::assertNull($resultUser);
+    }
+
+    public function testSuccessFindOneByPkWithDeletedTrue(): void
+    {
+        // arrange
+        $targetUser = self::USER_3;
+
+        // action
+        $resultUser = $this->manager->findOneByPk($targetUser['id'], true);
+
+        // assert
+        self::assertNotNull($resultUser);
+        self::assertEquals($targetUser['id'], $resultUser['id']);
+    }
+
     public function testFailFindOneByPkNoPrimaryKeyValue(): void
     {
         // assert
@@ -1244,6 +1269,27 @@ SQL
         self::assertEquals(0, $count);
     }
 
+    public function testSuccessUpdateByPkSoftDeletedRow(): void
+    {
+        // arrange
+        $targetUser = self::USER_3;
+        $id = $targetUser['id'];
+
+        $dataForUpdate = [
+            'name' => 'Updated User',
+            'birthday' => '2016-02-02',
+            'age' => 44,
+            'weight' => 32.4,
+            'married' => 1,
+        ];
+
+        // action
+        $count = $this->manager->updateByPk($id, $dataForUpdate);
+
+        // assert
+        self::assertEquals(0, $count);
+    }
+
     public function testSuccessBatchUpdate(): void
     {
         // arrange
@@ -1372,6 +1418,24 @@ SQL
         self::assertNull($deletedRow);
     }
 
+    public function testSuccessDeleteByPkSoftDeletedRow(): void
+    {
+        // arrange
+        $targetUser = self::USER_3;
+        $id = $targetUser['id'];
+
+        // action
+        $count = $this->manager->deleteByPk($id);
+
+        // assert
+        self::assertEquals(0, $count);
+
+        $deletedRow = $this->getOneRowFromDB([
+            'id' => $id,
+        ]);
+        self::assertNotNull($deletedRow);
+    }
+
     public function testSuccessDeleteAll(): void
     {
         // action
@@ -1416,6 +1480,25 @@ SQL
 
         // assert
         self::assertEquals(1, $count);
+
+        $deletedRow = $this->getOneRowFromDB([
+            'id' => $id,
+        ]);
+        self::assertNotNull($deletedRow);
+        self::assertNotNull($deletedRow[DefaultTestEntity::DELETED_AT_COLUMN]);
+    }
+
+    public function testSuccessSoftDeleteByPkAlreadySoftDeletedRow(): void
+    {
+        // arrange
+        $targetUser = self::USER_3;
+        $id = $targetUser['id'];
+
+        // action
+        $count = $this->manager->softDeleteByPk($id);
+
+        // assert
+        self::assertEquals(0, $count);
 
         $deletedRow = $this->getOneRowFromDB([
             'id' => $id,

--- a/tests/BaseManagerTestFoundation.php
+++ b/tests/BaseManagerTestFoundation.php
@@ -1231,6 +1231,19 @@ abstract class BaseManagerTestFoundation extends TestCase
 
         // assert
         self::assertEquals(0, $count);
+
+        $updatedUser = $this->getOneRowFromDB([
+            'id' => $id,
+        ]);
+        self::assertNotNull($updatedUser);
+        self::assertNotNull($updatedUser[DefaultTestEntity::DELETED_AT_COLUMN]);
+
+        self::assertEquals($targetUser['id'], $updatedUser['id']);
+        self::assertEquals($targetUser['name'], $updatedUser['name']);
+        self::assertEquals($targetUser['birthday'], $updatedUser['birthday']);
+        self::assertEquals($targetUser['age'], $updatedUser['age']);
+        self::assertEquals($targetUser['weight'], $updatedUser['weight']);
+        self::assertEquals($targetUser['married'], $updatedUser['married']);
     }
 
     public function testSuccessBatchUpdate(): void
@@ -1377,6 +1390,14 @@ abstract class BaseManagerTestFoundation extends TestCase
             'id' => $id,
         ]);
         self::assertNotNull($deletedRow);
+        self::assertNotNull($deletedRow[DefaultTestEntity::DELETED_AT_COLUMN]);
+
+        self::assertEquals($targetUser['id'], $deletedRow['id']);
+        self::assertEquals($targetUser['name'], $deletedRow['name']);
+        self::assertEquals($targetUser['birthday'], $deletedRow['birthday']);
+        self::assertEquals($targetUser['age'], $deletedRow['age']);
+        self::assertEquals($targetUser['weight'], $deletedRow['weight']);
+        self::assertEquals($targetUser['married'], $deletedRow['married']);
     }
 
     public function testSuccessDeleteAll(): void
@@ -1448,6 +1469,13 @@ abstract class BaseManagerTestFoundation extends TestCase
         ]);
         self::assertNotNull($deletedRow);
         self::assertNotNull($deletedRow[DefaultTestEntity::DELETED_AT_COLUMN]);
+
+        self::assertEquals($targetUser['id'], $deletedRow['id']);
+        self::assertEquals($targetUser['name'], $deletedRow['name']);
+        self::assertEquals($targetUser['birthday'], $deletedRow['birthday']);
+        self::assertEquals($targetUser['age'], $deletedRow['age']);
+        self::assertEquals($targetUser['weight'], $deletedRow['weight']);
+        self::assertEquals($targetUser['married'], $deletedRow['married']);
     }
 
     public function testSuccessSoftDeleteAll(): void


### PR DESCRIPTION
Я все-таки решил не добавлять `Filter` в метод `findOneByPk`, а удовольствовался одним булеаном. Там где требуется более сложный поиск по PK и другим полям, пусть клиент использует метод `findOneByFilter`.